### PR TITLE
bugfix: accept LSPRAG.provider: "ollama" (fixes #9)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -118,7 +118,7 @@ export type ProjectName = keyof typeof SRC_PATHS;
 const SEED = 12345; // Fixed seed for reproducibility
 let seededRandom: () => number;
 
-export type Provider = 'openai' | 'local' | 'deepseek';
+export type Provider = 'openai' | 'ollama' | 'deepseek';
 
 // Function to load private configuration
 
@@ -350,7 +350,7 @@ export class Configuration {
     }
 
     private adjustTimeout(): void {
-        if (this.provider === 'local' || this.provider === 'deepseek') {
+        if (this.provider === 'ollama' || this.provider === 'deepseek') {
             this.config.timeoutMs *= 2;
         }
     }

--- a/src/invokeLLM.ts
+++ b/src/invokeLLM.ts
@@ -46,7 +46,7 @@ export function getModelConfigError(): string | undefined {
 				return 'OpenAI API key is not configured. Please set LSPRAG.openaiApiKey in settings.';
 			}
 			break;
-		case 'local':
+		case 'ollama':
 			if (!getConfigInstance().localLLMUrl) {
 				return 'Local LLM URL is not configured. Please set LSPRAG.localLLMUrl in settings.';
 			}
@@ -127,7 +127,7 @@ export async function invokeLLM(promptObj: any, logObj: any, maxRetries = 2, ret
 				case 'openai':
 					response = await callOpenAi(promptObj, logObj);
 					break;
-				case 'local':
+				case 'ollama':
 					response = await callLocalLLM(promptObj, logObj);
 					break;
 				case 'deepseek':


### PR DESCRIPTION
The schema in package.json advertises "ollama" but the runtime switch only handled "local", causing "Unsupported provider" errors for anyone selecting from the settings dropdown. Renamed 'local' -> 'ollama' across the Provider type and switch cases so the code matches the schema and docs.

Cheers,
Nick